### PR TITLE
Render renderer as component

### DIFF
--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -330,7 +330,9 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
     const renderProps = this.getRenderProps();
 
     if (renderer) {
-      return renderer(renderProps);
+      const CustomRenderer = renderer;
+
+      return <CustomRenderer {...renderProps} />;
     }
 
     if (children && this.state.timeDelta.completed && !overtime) {


### PR DESCRIPTION
Fixes hook calls in renderer by calling React.createElement(renderer, renderProps) instead of renderer() (which causes "Hook call outside of function component error" if renderer function calls any hooks).