### PR TITLE
Invoke oncomplete if date has passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ If the current date and time (determined via a reference to `Date.now`) is not t
 `onTick` is a callback and triggered every time a new period is started, based on what the [`intervalDelay`](#intervaldelay)'s value is. It only gets triggered when the countdown's [`controlled`](#controlled) prop is set to `false`, meaning that the countdown has full control over its interval. It receives a [time delta object](#calctimedelta) as the first argument.
 
 ### `onComplete`
-`onComplete` is a callback and triggered whenever the countdown ends. In contrast to [`onTick`](#ontick), the [`onComplete`](#oncomplete) callback also gets triggered in case [`controlled`](#controlled) is set to `true`. It receives a [time delta object](#calctimedelta) as the first argument.
+`onComplete` is a callback and triggered whenever the countdown ends. In contrast to [`onTick`](#ontick), the [`onComplete`](#oncomplete) callback also gets triggered in case [`controlled`](#controlled) is set to `true`. It receives a [time delta object](#calctimedelta) as the first argument and a `boolean` as a second argument, indicating whether the countdown transitioned into the completed state (`false`) or completed on start (`true`).
 
 ## API Reference
 

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -485,6 +485,14 @@ describe('<Countdown />', () => {
     expect(wrapper.state().timeDelta.completed).toBe(true);
   });
 
+  it('should trigger onComplete if date is in the past', () => {
+    const completeHandler = jest.fn();
+    countdownDate = Date.now() - 10000;
+    wrapper = mount(<Countdown date={countdownDate} onComplete={completeHandler} />);
+
+    expect(completeHandler).toHaveBeenCalled();
+  });
+
   it('should not stop the countdown and go into overtime', () => {
     const onTick = jest.fn();
     wrapper = mount(

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -157,8 +157,8 @@ describe('<Countdown />', () => {
       seconds: 1,
     });
 
-    expect(onComplete.mock.calls.length).toBe(1);
-    expect(onComplete).toBeCalledWith({ ...defaultStats, completed: true });
+    expect(onComplete).toBeCalledTimes(1);
+    expect(onComplete).toBeCalledWith({ ...defaultStats, completed: true }, false);
     expect(wrapper.state().timeDelta.completed).toBe(true);
   });
 

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -179,7 +179,7 @@ describe('<Countdown />', () => {
       jest.runTimersToTime(1000);
     }
 
-    expect(calls).toEqual(['onStart', ...Array(10).fill('onTick'), 'onComplete']);
+    expect(calls).toEqual(['onStart', ...Array(9).fill('onTick'), 'onComplete']);
   });
 
   it('should trigger onComplete callback on start if date is in the past when countdown starts', () => {

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -490,7 +490,8 @@ describe('<Countdown />', () => {
     countdownDate = Date.now() - 10000;
     wrapper = mount(<Countdown date={countdownDate} onComplete={completeHandler} />);
 
-    expect(completeHandler).toHaveBeenCalled();
+    expect(completeHandler).toHaveBeenCalledTimes(1);
+    expect(completeHandler).toBeCalledWith({... defaultStats, completed: true}, true);
   });
 
   it('should not stop the countdown and go into overtime', () => {

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 import Countdown, { CountdownProps } from './Countdown';
-import { calcTimeDelta, CountdownTimeDelta, formatTimeDelta } from './utils';
+import { calcTimeDelta, formatTimeDelta } from './utils';
 
 import { CountdownProps as LegacyCountdownProps } from './LegacyCountdown';
 
@@ -174,12 +174,12 @@ describe('<Countdown />', () => {
 
     expect(calls).toEqual(['onStart']);
 
-    for (let i = 1; i <= 10; i++) {
+    for (let i = 1; i <= 10; i += 1) {
       now.mockReturnValue(countdownDate - countdownMs + i * 1000);
       jest.runTimersToTime(1000);
     }
 
-    expect(calls).toEqual(['onStart', ...new Array(9).fill('onTick'), 'onComplete']);
+    expect(calls).toEqual(['onStart', ...Array(10).fill('onTick'), 'onComplete']);
   });
 
   it('should trigger onComplete callback on start if date is in the past when countdown starts', () => {

--- a/src/Countdown.test.tsx
+++ b/src/Countdown.test.tsx
@@ -56,7 +56,7 @@ describe('<Countdown />', () => {
     const zeroPadTime = 0;
 
     class Completionist extends React.Component<any> {
-      componentDidMount() { }
+      componentDidMount() {}
 
       render() {
         return (
@@ -168,7 +168,9 @@ describe('<Countdown />', () => {
     const onStart = jest.fn().mockImplementation(() => calls.push('onStart'));
     const onTick = jest.fn().mockImplementation(() => calls.push('onTick'));
     const onComplete = jest.fn().mockImplementation(() => calls.push('onComplete'));
-    wrapper = mount(<Countdown date={countdownDate} onStart={onStart} onTick={onTick} onComplete={onComplete} />);
+    wrapper = mount(
+      <Countdown date={countdownDate} onStart={onStart} onTick={onTick} onComplete={onComplete} />
+    );
 
     expect(calls).toEqual(['onStart']);
 
@@ -177,7 +179,7 @@ describe('<Countdown />', () => {
       jest.runTimersToTime(1000);
     }
 
-    expect(calls).toEqual(['onStart', ...(new Array(9).fill('onTick')), 'onComplete']);
+    expect(calls).toEqual(['onStart', ...new Array(9).fill('onTick'), 'onComplete']);
   });
 
   it('should trigger onComplete callback on start if date is in the past when countdown starts', () => {
@@ -188,7 +190,9 @@ describe('<Countdown />', () => {
     const onComplete = jest.fn().mockImplementation(() => calls.push('onComplete'));
 
     countdownDate = Date.now() - 10000;
-    wrapper = mount(<Countdown date={countdownDate} onStart={onStart} onTick={onTick} onComplete={onComplete} />);
+    wrapper = mount(
+      <Countdown date={countdownDate} onStart={onStart} onTick={onTick} onComplete={onComplete} />
+    );
 
     expect(onStart).toHaveBeenCalledTimes(1);
     expect(onTick).not.toHaveBeenCalled();
@@ -635,6 +639,6 @@ describe('<Countdown />', () => {
   afterEach(() => {
     try {
       wrapper.detach();
-    } catch (e) { }
+    } catch (e) {}
   });
 });

--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -124,9 +124,6 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
         timeDelta,
         status: timeDelta.completed ? CountdownStatus.COMPLETED : CountdownStatus.STOPPED,
       };
-      if (timeDelta.completed && props.onComplete) {
-        props.onComplete(timeDelta, true);
-      }
     } else {
       this.legacyMode = true;
     }
@@ -197,6 +194,9 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
 
     const timeDelta = this.calcTimeDelta();
     this.setTimeDeltaState(timeDelta, CountdownStatus.STARTED, this.props.onStart);
+    if (timeDelta.completed && this.props.onComplete) {
+      this.props.onComplete(timeDelta, true);
+    }
 
     if (!this.props.controlled && (!timeDelta.completed || this.props.overtime)) {
       this.clearTimer();

--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -124,6 +124,9 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
         timeDelta,
         status: timeDelta.completed ? CountdownStatus.COMPLETED : CountdownStatus.STOPPED,
       };
+      if (timeDelta.completed && props.onComplete) {
+        props.onComplete(timeDelta);
+      }
     } else {
       this.legacyMode = true;
     }

--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -14,8 +14,8 @@ import {
 
 export interface CountdownProps
   extends React.Props<Countdown>,
-  CountdownTimeDeltaFormatOptions,
-  Omit<LegacyCountdownProps, 'onComplete'> {
+    CountdownTimeDeltaFormatOptions,
+    Omit<LegacyCountdownProps, 'onComplete'> {
   readonly date?: Date | number | string;
   readonly controlled?: boolean;
   readonly intervalDelay?: number;
@@ -31,7 +31,10 @@ export interface CountdownProps
   readonly onPause?: CountdownTimeDeltaFn;
   readonly onStop?: CountdownTimeDeltaFn;
   readonly onTick?: CountdownTimeDeltaFn;
-  readonly onComplete?: (timeDelta: CountdownTimeDelta, completedOnStart: boolean) => void | LegacyCountdownProps['onComplete'];
+  readonly onComplete?: (
+    timeDelta: CountdownTimeDelta,
+    completedOnStart: boolean
+  ) => void | LegacyCountdownProps['onComplete'];
 }
 
 export interface CountdownRenderProps extends CountdownTimeDelta {
@@ -262,7 +265,7 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
 
     const onDone = () => {
       if (callback) callback(this.state.timeDelta);
-      
+
       if (this.props.onComplete && (completing || completedOnStart)) {
         this.props.onComplete(timeDelta, completedOnStart);
       }

--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -31,7 +31,7 @@ export interface CountdownProps
   readonly onPause?: CountdownTimeDeltaFn;
   readonly onStop?: CountdownTimeDeltaFn;
   readonly onTick?: CountdownTimeDeltaFn;
-  readonly onComplete?: CountdownTimeDeltaFn | LegacyCountdownProps['onComplete'];
+  readonly onComplete?: (timeDelta: CountdownTimeDelta, completedBeforeInit: boolean) => void | LegacyCountdownProps['onComplete'];
 }
 
 export interface CountdownRenderProps extends CountdownTimeDelta {
@@ -125,7 +125,7 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
         status: timeDelta.completed ? CountdownStatus.COMPLETED : CountdownStatus.STOPPED,
       };
       if (timeDelta.completed && props.onComplete) {
-        props.onComplete(timeDelta);
+        props.onComplete(timeDelta, true);
       }
     } else {
       this.legacyMode = true;
@@ -250,7 +250,7 @@ export default class Countdown extends React.Component<CountdownProps, Countdown
   }
 
   handleOnComplete = (timeDelta: CountdownTimeDelta): void => {
-    if (this.props.onComplete) this.props.onComplete(timeDelta);
+    if (this.props.onComplete) this.props.onComplete(timeDelta, false);
   };
 
   setTimeDeltaState(


### PR DESCRIPTION
As discussed in #169, it could be helpful to invoke the `onComplete` callback if the provided date has passed by the time the `Countdown` component has been initialized. Per @ndresx's suggestion in the mentioned issue, the callback is now being invoked with a second argument to specify whether this is the case or not.

Please let me know if you have any feedback; I'll be happy to amend the code.

Resolves #169 