### PR TITLE
v2.3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       run: yarn install
 
     - name: "Tests: Unit"
-      run: yarn test
+      run: yarn test:coverage
 
     - name: "Tests: E2E"
       run: yarn test:e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -54,7 +54,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -93,7 +93,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -124,7 +124,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -54,7 +54,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -93,7 +93,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache
@@ -124,7 +124,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: yarn-cache

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ import Countdown, { zeroPad, calcTimeDelta, formatTimeDelta } from 'react-countd
 ```
 
 ### `zeroPad(value, [length = 2])`
-The `zeroPad` function works similarly to other well-known pad-functions and takes two arguments into account. A `value` which can be a `string` or `number`, as well as a `length` parameter that defaults to `2` as you are most likely only going to use this function if you actually want to pad one of your values. Either returns a `number` if `length` equals `0`, or the zero-padded `string`.
+The `zeroPad` function returns a given `value` with padded zeros depending on the `length`. The `value` can be a `string` or `number`, while the `length` parameter can be a `number`, defaulting to `2`. Returns the zero-padded `string`, e.g., `zeroPad(5)` => `05`.
 
 ```js
 const renderer = ({ hours, minutes, seconds }) => (

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ import Countdown, { zeroPad, calcTimeDelta, formatTimeDelta } from 'react-countd
 ```
 
 ### `zeroPad(value, [length = 2])`
-The `zeroPad` function returns a given `value` with padded zeros depending on the `length`. The `value` can be a `string` or `number`, while the `length` parameter can be a `number`, defaulting to `2`. Returns the zero-padded `string`, e.g., `zeroPad(5)` => `05`.
+The `zeroPad` function transforms and returns a given `value` with padded zeros depending on the `length`. The `value` can be a `string` or `number`, while the `length` parameter can be a `number`, defaulting to `2`. Returns the zero-padded `string`, e.g., `zeroPad(5)` => `05`.
 
 ```js
 const renderer = ({ hours, minutes, seconds }) => (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-countdown",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A customizable countdown component for React.",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "lint:tsc": "tsc --noEmit",
     "prettier-check": "prettier --list-different ./src/**/*.{ts,tsx}",
     "prettier": "prettier --write ./src/**/*.{ts,tsx}",
-    "test": "jest --coverage",
+    "test": "jest",
+    "test:coverage": "jest --coverage"    
     "test:e2e": "yarn start-server-and-test test:e2e:server http://localhost:1234 \"cypress run\"",
     "test:e2e:clean": "rm -rf ./e2e/dist",
     "test:e2e:dev": "yarn start-server-and-test test:e2e:server http://localhost:1234 \"cypress open\"",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier-check": "prettier --list-different ./src/**/*.{ts,tsx}",
     "prettier": "prettier --write ./src/**/*.{ts,tsx}",
     "test": "jest",
-    "test:coverage": "jest --coverage"    
+    "test:coverage": "jest --coverage",
     "test:e2e": "yarn start-server-and-test test:e2e:server http://localhost:1234 \"cypress run\"",
     "test:e2e:clean": "rm -rf ./e2e/dist",
     "test:e2e:dev": "yarn start-server-and-test test:e2e:server http://localhost:1234 \"cypress open\"",

--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -16,7 +16,7 @@ export interface CountdownProps
   extends React.Props<Countdown>,
     CountdownTimeDeltaFormatOptions,
     Omit<LegacyCountdownProps, 'onComplete'> {
-  readonly date?: Date | number | string;
+  readonly date: Date | number | string;
   readonly controlled?: boolean;
   readonly intervalDelay?: number;
   readonly precision?: number;


### PR DESCRIPTION
## Changelog
- Updates `onComplete` callback to consistently trigger, even when the countdown is completed on start. [#169](https://github.com/ndresx/react-countdown/pull/194)

## Bugfixes
- Fixes #175
The `CountdownProps` interface `date` prop was initially set to optional due to an older component that is still being supported in order to follow Semver (for `react-countdown@2`). This change will make it a required one. However, since this legacy version was neither utilizing TypeScript nor PropTypes, it's safe to assume that this won't break anything given that the actual countdown component only works by providing this prop while it's also documented this way. 