### PR TITLE
change React.Props to PropsWithChildren

### DIFF
--- a/src/Countdown.tsx
+++ b/src/Countdown.tsx
@@ -13,7 +13,7 @@ import {
 } from './utils';
 
 export interface CountdownProps
-  extends React.Props<Countdown>,
+  extends React.PropsWithChildren<Countdown>,
     CountdownTimeDeltaFormatOptions,
     Omit<LegacyCountdownProps, 'onComplete'> {
   readonly date: Date | number | string;


### PR DESCRIPTION
error TS2694: Namespace 'React' has no exported member 'Props'.